### PR TITLE
Multicatches and improvements on /botprobability

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -110,16 +110,20 @@ class BotProbability():
         return predicted_proba
 
     def botProbability(self, handle, twitterTimeline, twitterUserData):
+        analise = 0
         try:
             df_timeline = pd.DataFrame.from_dict(twitterTimeline)
-            df_user_data = pd.DataFrame.from_dict(twitterUserData)
+            df_user_data = pd.DataFrame([twitterUserData])
             analise = self.predict(df_user_data, df_timeline)
             self.total = round(analise[0][1]*100, 2)
+
         except:
-            self.total = -1
+             raise Exception("Problem(s) probably in predict function")    
+
 
         return edict({
             'pegabot_version': 'version-1.0',
             'handle': handle,
-            'total': self.total
+            'total': self.total,
+            'analysis': analise.tolist()
         })

--- a/app/models/prepare_data.py
+++ b/app/models/prepare_data.py
@@ -26,6 +26,9 @@ class MLTools:
         df_users['É bot?'] = ''
 
         #Extrai as informações de retweet
+        if not('tweet_is_retweet' in df_timeline.columns and 'tweet_text' in df_timeline.columns):
+            raise Exception("Problems on tweets")
+        
         df_timeline['retweet_tratado'] = df_timeline['tweet_is_retweet'].apply(lambda x: "sim" if (x == 'True' or x == True) else "não")
         df_timeline['tweet_com_rt_tratado'] = df_timeline['tweet_text'].apply(lambda x: "sim" if x.find("RT @") != -1 else "não" )
 
@@ -91,7 +94,7 @@ class MLTools:
         df = df_result_merge
 
         #Monta o conjunto de treinamento
-        feature_cols = ['followers_count', 'friends_count', 'Tempo mediano', 'Tempo menor']
+        feature_cols = ['twitter_followers_count', 'twitter_friends_count', 'Tempo mediano', 'Tempo menor']
         x = df[feature_cols]
 
         qtd_hashtags = df['tweet_hashtags'].apply(lambda x: len(x.replace("[","").replace("]","").replace(", \'","$").split("$")))
@@ -105,7 +108,7 @@ class MLTools:
 
         #O tamanho do nome e do login
         tam_username = df['handle'].apply(lambda x: len(str(x)))
-        tam_nome = df['name'].apply(lambda x: len(str(x)))
+        tam_nome = df['twitter_user_name'].apply(lambda x: len(str(x)))
         x['Tamanho do username'] = np.array(list(tam_username))
         x['Tamanho do nome'] = np.array(list(tam_nome))
 

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -3,7 +3,6 @@ from flask import jsonify, request
 from app.models.models import Analises, AnaliseSchema
 from app.services.botometer_service import BotometerService
 
-
 @app.get("/catch")
 def catch():
     handle = str(request.args.get('profile'))
@@ -31,3 +30,15 @@ def complete():
 def feedback():
     return jsonify("feedback")
 
+@app.get('/multicatches')
+def multicatches():
+    handle = str(request.args.get('profiles'))
+    users = handle.split(',')
+
+    results = list()
+    for user in users:
+        botometer_service = BotometerService()
+        response = botometer_service.catch(user)
+        results.append(response)
+
+    return jsonify(results), 200

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -2,6 +2,7 @@ from app import app
 from flask import jsonify, request
 from app.models.models import Analises, AnaliseSchema
 from app.services.botometer_service import BotometerService
+from concurrent.futures import ThreadPoolExecutor
 
 @app.get("/catch")
 def catch():
@@ -40,5 +41,21 @@ def multicatches():
         botometer_service = BotometerService()
         response = botometer_service.catch(user)
         results.append(response)
+
+    return jsonify(results), 200
+
+@app.get('/multicatchesparallel')
+def multicatches2():
+    handle = str(request.args.get('profiles'))
+    users = handle.split(',')
+    results = list()
+
+    def getResult(username):
+        botometer_service = BotometerService()
+        response = botometer_service.catch(username)
+        results.append(response)
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        pool.map(getResult, users)
 
     return jsonify(results), 200

--- a/app/services/botometer_service.py
+++ b/app/services/botometer_service.py
@@ -105,7 +105,10 @@ class BotometerService():
                 db.session.add(analise)
                 db.session.commit()
 
-    def botProbability(self, handle, user, timeline):
+    def botProbability(self, handle):
         p = BotProbability()
+        user = self.findUserAnalisisByHandle(handle=handle)
+        response = self.twitter_handler.findByHandle(handle=handle)
+        timeline = self.twitter_handler.getUserTimeline(response.twitter_id)
         response = p.botProbability(handle=handle, twitterTimeline=timeline, twitterUserData=user)
         return response


### PR DESCRIPTION
### **O que há de novo nessa versão:**

1. Criação do endpoint /multicatches 
2. Criação do endpoint /multicatchesParallel 
3.  Melhorias de endpoint  /botprobability


### Mais detalhes:

1. Criação do endpoint /multicatches 
 
Exemplo endpoint :
 `127.0.0.1:5000/multicatches?profiles=elonMusk,NeymarJr`

Permite que o usuário em uma requisição pesquise múltiplos perfis. No código essa busca é feita de forma sequencial
(permitindo futuramente espaçar o período entre requisições para reduzir riscos de bloqueio de token)

2. Criação do endpoint /multicatchesparallel

Exemplo endpoint:
 `127.0.0.1:5000/multicatchesparallel?profiles=elonMusk,NeymarJr`

Permite que o usuário em uma requisição pesquise múltiplos perfis em paralelo, utilizando threads (logo, buscando dados de forma mais rápida)

OBS: O resultado do /multicatches é igual ao do /multicatchesparallel o que muda é a forma como são implementados.

3. Melhorias de endpoint  /botprobability

- Ajuste da assinatura da função botProbability
- Renomeação de campos na hora da análise para ficarem similares ao do banco
- Identificação de alguns locais que precisam de ajuste levantando exceções para futuras análises

Exemplo endpoint :
`127.0.0.1:5000/botprobability?profile=elonMusk`

Resultado da requisição atual do /botprobability (antes os valores eram apenas default): 

```
{
	"pegabot_version": "version-1.0",
	"handle": "elonMusk",
	"total": 28.11,
	"analysis": [
		[
			0.7189322947156052,
			0.28106770528439484
		]
	]
}
```

OBS: O /botprobability é funcional apenas para usuários com contas muito movimentadas como famosos


Hackthon Pegabot 2022 - Categoria 1
Grupo 1A;
Iraline Nunes
Gabriel Augusto
Mario Mendonça
 